### PR TITLE
bug fix(CC): fix a bug causing double ingredient use when crafting

### DIFF
--- a/ConvenientChests/CraftFromChests/CraftFromChestsModule.cs
+++ b/ConvenientChests/CraftFromChests/CraftFromChestsModule.cs
@@ -59,7 +59,9 @@ internal class CraftFromChestsModule : IModule
             page._materialContainers = inventories.ToList();
 
         else
-            page._materialContainers.AddRange(inventories);
+            foreach (var inv in inventories.ToList())
+                if (!page._materialContainers.Contains(inv))
+                    page._materialContainers.Add(inv);
     }
 
     private IEnumerable<Chest> GetChests(bool isCookingScreen)


### PR DESCRIPTION
This solves bug report #6. I've seen reports of this bug on nexus too. Definitely solves the issue for me.
I don't know what the cause of the bug is, But it was present on the original mod too.
Could be considered a hotfix before a better solution is implemented.